### PR TITLE
Upgrade to Agones 1.6.0

### DIFF
--- a/terraform-4-cluster/README.md
+++ b/terraform-4-cluster/README.md
@@ -30,6 +30,9 @@ You may need to increase your
 
 ## Running the example
 
+Before running the example, make sure you have applied the IAM permission changes outlined in
+[Registering a cluster](https://cloud.google.com/game-servers/docs/how-to/registering-cluster#registering_a_cluster).
+
 To create the example in your project:
 
 ```shell script

--- a/terraform-4-cluster/configs/fleet-v1-gcloud.yaml
+++ b/terraform-4-cluster/configs/fleet-v1-gcloud.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# A singular Fleet "spec" to be applied to a GCGS Config
+# See: https://agones.dev/site/docs/reference/fleet/ for reference
+#
+# Formatted as needed for gcloud commands
+#
+
+- name: supertuxkart
+  fleetSpec:
+    replicas: 2
+    template:
+      metadata:
+        labels:
+          version: "1.0"
+      spec:
+        ports:
+        - name: default
+          containerPort: 8080
+        health:
+          initialDelaySeconds: 30
+          periodSeconds: 60
+        template:
+          spec:
+            containers:
+            - name: supertuxkart
+              image: gcr.io/agones-images/supertuxkart-example:0.2

--- a/terraform-4-cluster/configs/fleet-v1-tf.yaml
+++ b/terraform-4-cluster/configs/fleet-v1-tf.yaml
@@ -16,6 +16,8 @@
 # A singular Fleet "spec" to be applied to a GCGS Config
 # See: https://agones.dev/site/docs/reference/fleet/ for reference
 #
+# Formatted as needed for Terrafrom
+#
 
 replicas: 2
 template:

--- a/terraform-4-cluster/main.tf
+++ b/terraform-4-cluster/main.tf
@@ -110,7 +110,7 @@ resource "google_game_services_game_server_config" "v1" {
 
   fleet_configs {
     name       = "supertuxkart"
-    fleet_spec = jsonencode(yamldecode(file("./configs/fleet-v1.yaml")))
+    fleet_spec = jsonencode(yamldecode(file("./configs/fleet-v1-tf.yaml")))
   }
 }
 


### PR DESCRIPTION
This includes changing Terraform to point to the 1.6.0 Terraform scripts, as well as installing cert-manager with the Agones cluster
details.

This also includes both the terraform and gcloud configurations for the fleet, so that users can see the difference.