### PR TITLE
Handy destroy.sh script

### DIFF
--- a/terraform-4-cluster/README.md
+++ b/terraform-4-cluster/README.md
@@ -38,6 +38,12 @@ terraform init
 terraform apply -var project="<YOUR_GCP_ProjectID>"
 ```
 
+## Cleaning up
+
+Deleting clusters with Kubernetes services installed can leave behind orphaned resources within your Google
+Cloud project. We provided [destroy.sh](destroy.sh) as a handy script for cleaning up your resources by deleting the
+Helm installation first. It assumes you have [Helm v2.x](https://v2.helm.sh/docs/) installed in your path. 
+
 [tf]: https://www.terraform.io/
 [agones]: https://agones.dev/
 [citadel]: https://istio.io/docs/ops/deployment/architecture/#citadel

--- a/terraform-4-cluster/destroy.sh
+++ b/terraform-4-cluster/destroy.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+#
+# Since deleting a cluster with resources in it can leave behind orphaned resources
+# such as load balancers, here's a short script to delete helm installations
+# before deleting the infrastructure.
+#
+
+# Assuming Helm 2.x at this point, but run upgrade in case local version isn't the same as the Terraform version
+upgrade_helm() {
+  gcloud container clusters get-credentials $1 --zone $2
+  helm init --upgrade
+}
+
+delete_helm() {
+  gcloud container clusters get-credentials $1 --zone $2
+  helm delete --purge agones
+}
+
+gcloud container clusters list --format="value(name,zone)" | grep game-cluster | while read -r line ; do
+    upgrade_helm $line
+done
+
+echo "Helm upgrade complete, waiting for a minute to finalise..."
+sleep 60
+
+gcloud container clusters list --format="value(name,zone)" | grep game-cluster | while read -r line ; do
+    delete_helm $line
+done
+
+terraform destroy


### PR DESCRIPTION
Handy cleanup script, since if you delete the cluster without removing externally facing Kubernetes services in the clusters, you could end up with orphaned load balancers in GCP.