### PR TITLE
Generate certs for multi-cluster allocation

### DIFF
--- a/terraform-4-cluster/.gitignore
+++ b/terraform-4-cluster/.gitignore
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 !.gitignore
+/allocation/certs/
 
 # Created by .ignore support plugin (hsz.mobi)
 ### Terraform template

--- a/terraform-4-cluster/README.md
+++ b/terraform-4-cluster/README.md
@@ -41,6 +41,19 @@ terraform init
 terraform apply -var project="<YOUR_GCP_ProjectID>"
 ```
 
+## Multi-cluster Allocation
+
+We're still working out how to configure the certificate authentication part of Multi-cluster allocation to Terraform.
+
+In the meantime, `gen-certs.sh` will create and apply the requisite certificates, as well as save them locally for
+authentication against the [allocation service](https://agones.dev/site/docs/advanced/allocator-service/).
+
+`allocate.sh` also provides a convenience script for passing those certificates to the 
+[allocator sample client](https://agones.dev/site/docs/advanced/multi-cluster-allocation/#allocate-multi-cluster). To
+use this script export the environment variable `ALLOCATION_PATH` to point to the 
+[allocator sample client](https://agones.dev/site/docs/advanced/multi-cluster-allocation/#allocate-multi-cluster)
+directory.
+
 [tf]: https://www.terraform.io/
 [agones]: https://agones.dev/
 [citadel]: https://istio.io/docs/ops/deployment/architecture/#citadel

--- a/terraform-4-cluster/allocation/allocate.sh
+++ b/terraform-4-cluster/allocation/allocate.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+NAMESPACE=default
+EXTERNAL_IP=`kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`
+CERT_FOLDER=$(pwd)/certs/$(kubectl config current-context)
+
+cd "${ALLOCATION_PATH}"
+go run main.go --ip ${EXTERNAL_IP} \
+    --namespace ${NAMESPACE} \
+    --key "${CERT_FOLDER}/client.key" \
+    --cert "${CERT_FOLDER}/client.crt" \
+    --cacert "${CERT_FOLDER}/ca.crt" \
+    --multicluster true

--- a/terraform-4-cluster/allocation/gen-certs.sh
+++ b/terraform-4-cluster/allocation/gen-certs.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+#
+# Script to setup server and client certificates appropriately across
+# all the clusters
+# Created from: https://agones.dev/site/docs/advanced/allocator-service/
+#
+
+# Return CERT_FOLDER after this is run.
+cluster_setup() {
+  echo "Setting up cluster: $1 $2"
+  gcloud container clusters get-credentials $1 --zone $2
+  CERT_FOLDER=./certs/$(kubectl config current-context)
+  mkdir -p "$CERT_FOLDER" || true
+}
+
+server_cert() {
+  echo "Setting up server certs: $1 $2"
+
+  #!/bin/bash
+  # Create a self-signed ClusterIssuer
+cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+EOF
+
+  EXTERNAL_IP=`kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`
+
+  # Create a Certificate with IP for the allocator-tls secret
+cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: allocator-selfsigned-cert
+  namespace: agones-system
+spec:
+  commonName: ${EXTERNAL_IP}
+  ipAddresses:
+    - ${EXTERNAL_IP}
+  secretName: allocator-tls
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+EOF
+
+  # Optional: Store the secret ca.crt in a file to be used by the client for the server authentication
+  TLS_CA_FILE=$CERT_FOLDER/ca.crt
+  TLS_CA_VALUE=`kubectl get secret allocator-tls -n agones-system -ojsonpath='{.data.ca\.crt}'`
+  echo ${TLS_CA_VALUE} | base64 -d > ${TLS_CA_FILE}
+
+  # In case of MacOS
+  # echo ${TLS_CA_VALUE} | base64 -D > ${TLS_CA_FILE}
+
+  # Add ca.crt to the allocator-tls-ca Secret
+  kubectl get secret allocator-tls-ca -o json -n agones-system | jq '.data["tls-ca.crt"]="'${TLS_CA_VALUE}'"' | kubectl apply -f -
+}
+
+client_cert() {
+  echo "Setting up server certs: $1 $2"
+
+  KEY_FILE=$CERT_FOLDER/client.key
+  CERT_FILE=$CERT_FOLDER/client.crt
+
+  openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ${KEY_FILE} -out ${CERT_FILE} -subj "/C=/ST=/L=/O=/OU=/CN="
+
+  CERT_FILE_VALUE=`cat ${CERT_FILE} | base64 -w 0`
+
+  # In case of MacOS
+  # CERT_FILE_VALUE=`cat ${CERT_FILE} | base64`
+
+  # white-list client certificate
+  kubectl get secret allocator-client-ca -o json -n agones-system | jq '.data["client_trial.crt"]="'${CERT_FILE_VALUE}'"' | kubectl apply -f -
+}
+
+gcloud container clusters list --format="value(name,zone)" | grep game-cluster | while read -r line ; do
+    cluster_setup $line
+    server_cert $line
+    client_cert $line
+    kubectl get pods -n agones-system -o=name | grep agones-allocator | xargs kubectl delete -n agones-system
+done


### PR DESCRIPTION
This includes a bash script to generate and retrieve certs for multi-cluster allocation, as well as a handy invocation script for the
allocator example, with the appropriate paths to the stored certs as well.