### PR TITLE
Trigger reconciliation after cluster secret changes

### DIFF
--- a/terraform-4-cluster/README.md
+++ b/terraform-4-cluster/README.md
@@ -54,6 +54,9 @@ use this script export the environment variable `ALLOCATION_PATH` to point to th
 [allocator sample client](https://agones.dev/site/docs/advanced/multi-cluster-allocation/#allocate-multi-cluster)
 directory.
 
+If there is a failure while running `allocate.sh` give it a few minutes before running the script again.
+The wait is for Game Servers to synchronize resources across clusters.
+
 ## Cleaning up
 
 ```shell script

--- a/terraform-4-cluster/agones-cluster/main.tf
+++ b/terraform-4-cluster/agones-cluster/main.tf
@@ -22,7 +22,7 @@ terraform {
 
 // Create a GKE cluster with the appropriate structure
 module "agones_cluster" {
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=release-1.8.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=release-1.9.0"
 
   cluster = {
     "name"             = var.name
@@ -36,9 +36,9 @@ module "agones_cluster" {
 
 // Install Agones via Helm
 module "helm_agones" {
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=release-1.8.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=release-1.9.0"
 
-  agones_version         = "1.8.0"
+  agones_version         = "1.9.0"
   values_file            = ""
   chart                  = "agones"
   host                   = module.agones_cluster.host
@@ -81,7 +81,7 @@ resource "helm_release" "cert_manager" {
   force_update = "true"
   repository = data.helm_repository.jetstack.metadata.0.name
   chart = "cert-manager"
-  version = "v0.15.1"
+  version = "v1.0.3"
   timeout = 420
   namespace = "cert-manager"
   create_namespace = true


### PR DESCRIPTION
(1) When running gen-certs.sh, secrets on the cluster are changed using cert-manager for the first time. For Game Servers to trigger clusters reconciliation, make an update to the realm.

(2) Mac openssl requires CN to be set, since this is for client certificate, we set it to a random CN name.

(3) Upgrade to use Agones v1.9.

(4) Remove the step to restart the servers when certs are changed.

(5) Upgraded the cert-manager dependency to stable version.

Closes #8