### PR TITLE
Update Example to Agones 1.12.0

### DIFF
--- a/terraform-4-cluster/README.md
+++ b/terraform-4-cluster/README.md
@@ -28,6 +28,10 @@ You may need to increase your
 [Google Cloud Project Quotas for CPUs and External IP addresses](https://console.cloud.google.com/iam-admin/quotas), as this example creates
 4 clusters, each with 6 n1-standard-4 nodes - 2 in europe-west4 and 2 in us-central1.
 
+## Terraform version support
+
+This example was built using Terraform 0.12, and has not yet been updated to 0.13 and above.
+
 ## Running the example
 
 Before running the example, make sure you have applied the IAM permission changes outlined in

--- a/terraform-4-cluster/agones-cluster/main.tf
+++ b/terraform-4-cluster/agones-cluster/main.tf
@@ -22,7 +22,7 @@ terraform {
 
 // Create a GKE cluster with the appropriate structure
 module "agones_cluster" {
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=release-1.9.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=release-1.12.0"
 
   cluster = {
     "name"             = var.name
@@ -36,9 +36,9 @@ module "agones_cluster" {
 
 // Install Agones via Helm
 module "helm_agones" {
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=release-1.9.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=release-1.12.0"
 
-  agones_version         = "1.9.0"
+  agones_version         = "1.12.0"
   values_file            = ""
   chart                  = "agones"
   host                   = module.agones_cluster.host
@@ -69,17 +69,10 @@ provider "helm" {
   }
 }
 
-data "helm_repository" "jetstack" {
-  name = "jetstack"
-  url  = "https://charts.jetstack.io"
-
-  depends_on = [module.helm_agones]
-}
-
 resource "helm_release" "cert_manager" {
   name = "cert-manager"
   force_update = "true"
-  repository = data.helm_repository.jetstack.metadata.0.name
+  repository = "https://charts.jetstack.io"
   chart = "cert-manager"
   version = "v1.0.3"
   timeout = 420


### PR DESCRIPTION
Since there are breaking changes between Terraform 0.12 -> 0.13 and above I made note of the current version support for the repository.

Also removed the deprecation of `helm_repository` while I was updating the modules.