### PR TITLE
Updated Terraform files to support Terraform >0.13

### DIFF
--- a/terraform-4-cluster/agones-cluster/main.tf
+++ b/terraform-4-cluster/agones-cluster/main.tf
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 terraform {
   required_providers {
-    google      = "~> 3.35"
-    google-beta = "~> 3.35"
+    google      = "~> 3.84"
+    google-beta = "~> 3.84"
     helm        = "~> 1.2"
   }
 }
 
 // Create a GKE cluster with the appropriate structure
 module "agones_cluster" {
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=release-1.12.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=release-1.16.0"
 
   cluster = {
     "name"             = var.name
@@ -37,9 +36,9 @@ module "agones_cluster" {
 
 // Install Agones via Helm
 module "helm_agones" {
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=release-1.13.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=release-1.16.0"
 
-  agones_version         = "1.12.0"
+  agones_version         = "1.16.0"
   values_file            = ""
   chart                  = "agones"
   host                   = module.agones_cluster.host
@@ -59,10 +58,9 @@ module "citadel" {
 // Install cert-manager.io
 provider "helm" {
 
-  debug           = true
+  debug = true
 
   kubernetes {
-    load_config_file       = false
     host                   = module.agones_cluster.host
     token                  = module.agones_cluster.token
     cluster_ca_certificate = module.agones_cluster.cluster_ca_certificate

--- a/terraform-4-cluster/agones-cluster/main.tf
+++ b/terraform-4-cluster/agones-cluster/main.tf
@@ -17,6 +17,7 @@ terraform {
   required_providers {
     google      = "~> 3.35"
     google-beta = "~> 3.35"
+    helm        = "~> 1.2"
   }
 }
 
@@ -36,7 +37,7 @@ module "agones_cluster" {
 
 // Install Agones via Helm
 module "helm_agones" {
-  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=release-1.12.0"
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=release-1.13.0"
 
   agones_version         = "1.12.0"
   values_file            = ""
@@ -57,7 +58,6 @@ module "citadel" {
 
 // Install cert-manager.io
 provider "helm" {
-  version = "~> 1.2"
 
   debug           = true
 

--- a/terraform-4-cluster/agones-cluster/main.tf
+++ b/terraform-4-cluster/agones-cluster/main.tf
@@ -15,7 +15,6 @@
 terraform {
   required_providers {
     google      = "~> 3.84"
-    google-beta = "~> 3.84"
     helm        = "~> 1.2"
   }
 }

--- a/terraform-4-cluster/citadel/main.tf
+++ b/terraform-4-cluster/citadel/main.tf
@@ -17,8 +17,13 @@ Module to install Citadel (https://istio.io/docs/ops/deployment/architecture/#ci
 To secure cross-cluster communication between Multi Cluster Allocation endpoints
 */
 
+terraform {
+  required_providers {
+    kubernetes = "~> 2.5.0"
+  }
+}
+
 provider "kubernetes" {
-  //config_path          = "~/.kube/config"
   host                   = var.host
   token                  = var.token
   cluster_ca_certificate = var.cluster_ca_certificate

--- a/terraform-4-cluster/citadel/main.tf
+++ b/terraform-4-cluster/citadel/main.tf
@@ -18,7 +18,7 @@ To secure cross-cluster communication between Multi Cluster Allocation endpoints
 */
 
 provider "kubernetes" {
-  load_config_file       = false
+  //config_path          = "~/.kube/config"
   host                   = var.host
   token                  = var.token
   cluster_ca_certificate = var.cluster_ca_certificate
@@ -160,7 +160,7 @@ resource "kubernetes_deployment" "istio_citadel" {
           }
 
           resources {
-            requests {
+            requests = {
               cpu = "10m"
             }
           }

--- a/terraform-4-cluster/main.tf
+++ b/terraform-4-cluster/main.tf
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC All Rights Reserved.
+// Copyright 2020 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/terraform-4-cluster/main.tf
+++ b/terraform-4-cluster/main.tf
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC All Rights Reserved.
+// Copyright 2021 Google LLC All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,23 @@
 // Run:
 // terraform apply -var project="<YOUR_GCP_ProjectID>"
 
+terraform {
+  required_providers {
+    google = {
+      source = "google"
+      version = "~> 3.35"
+    }
+    google-beta = {
+      source = "google-beta"
+      version = "~> 3.35"
+    }
+  }
+}
+
 provider "google" {
-  version = "~> 3.35"
 }
 
 provider "google-beta" {
-  version = "~> 3.35"
 }
 
 variable "project" {

--- a/terraform-4-cluster/main.tf
+++ b/terraform-4-cluster/main.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source = "google"
-      version = "~> 3.35"
+      version = "~> 3.84"
     }
     google-beta = {
       source = "google-beta"
-      version = "~> 3.35"
+      version = "~> 3.84"
     }
   }
 }

--- a/terraform-4-cluster/main.tf
+++ b/terraform-4-cluster/main.tf
@@ -21,17 +21,10 @@ terraform {
       source = "google"
       version = "~> 3.84"
     }
-    google-beta = {
-      source = "google-beta"
-      version = "~> 3.84"
-    }
   }
 }
 
 provider "google" {
-}
-
-provider "google-beta" {
 }
 
 variable "project" {


### PR DESCRIPTION
In Terraform 0.13 and later, provider requirements are declared in a required_providers block. In previous version of Terraform, versions could be declared directly within the provider block.
 
**References:** 
https://www.terraform.io/docs/language/providers/requirements.html#requiring-providers
https://www.terraform.io/upgrade-guides/0-13.html

**What was modified:** 

1)  Updated **./main.tf** to use the required_providers block to declare provider versions.

2)  Updated **./agones-cluster/main.tf** to use the required_providers block to declare provider versions. Also referenced an updated helm module (that works with Terraform >0.13), by switching from release-1.12.0 to release-1.13.0 (https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=release-1.13.0)

3) Updated **./citadel/main.tf** to remove load_config_file, since it is now referenced in a different way (https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#file-config). The flag was set to false anyway, so I just commented out this line and replaced with a proper config reference. Also updated requests to include an equal (=) sign in the kubernetes_deployment resources, which is now required. (https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment)

Tested with Terraform v1.0.5
on linux_amd64